### PR TITLE
Removed bug regarding play button in help menu

### DIFF
--- a/js/hextris-lite.js
+++ b/js/hextris-lite.js
@@ -480,6 +480,10 @@ function checkGameOver() {
 }
 
 function showHelp() {
+    if (gameState == 0) {
+		$('#startBtn').toggle();
+    }
+    
     if ($('#openSideBar').attr('src') == './images/btn_back.svg') {
         $('#openSideBar').attr('src', './images/btn_help.svg');
         if (gameState != 0 && gameState != -1 && gameState != 2) {


### PR DESCRIPTION
When opening the help screen, the play button becomes invisible but is still clickable. All the buttons disappear if a player clicks the invisible play button (and the user can no longer preform any action.

This pull request fixes above described problem.

Special thanks to @tytoons for fixing this bug in original  hextris.